### PR TITLE
Memory Leak Fix

### DIFF
--- a/src/main/java/com/sun/media/imageioimpl/plugins/jpeg2000/J2KImageReader.java
+++ b/src/main/java/com/sun/media/imageioimpl/plugins/jpeg2000/J2KImageReader.java
@@ -565,6 +565,17 @@ public class J2KImageReader extends ImageReader implements MsgLogger {
         }
         return null;
     }
+    
+    //Implemented to fix Memory Leak in JAI Sun Impl
+    public void dispose(){
+    	if(iis != null){
+    		iis.dispose();
+    	}
+    	
+        imageMetadata = null;
+        hd = null;
+        readState = null;
+    }
 
     // --- Begin jj2000.j2k.util.MsgLogger implementation ---
     public void flush() {


### PR DESCRIPTION
Sun's implementation of the JP2 reader has a bad memory leak. I implemented the required dispose method to fix the bug.

See this post: http://www.jpedal.org/PDFblog/2011/03/java-jai-image-io-jpeg2000-memory-leak-fix/
