### PR TITLE
Native memory leak when writing TIFFs (DEFLATE)

### DIFF
--- a/src/main/java/com/github/jaiimageio/impl/plugins/tiff/TIFFDeflater.java
+++ b/src/main/java/com/github/jaiimageio/impl/plugins/tiff/TIFFDeflater.java
@@ -140,4 +140,12 @@ public class TIFFDeflater extends TIFFCompressor {
 
         return numCompressedBytes;
     }
+    
+    public void dispose() {
+      if (deflater != null) {
+        deflater.end();
+        deflater = null;
+      }
+      super.dispose();
+    }
 }

--- a/src/main/java/com/github/jaiimageio/impl/plugins/tiff/TIFFImageWriter.java
+++ b/src/main/java/com/github/jaiimageio/impl/plugins/tiff/TIFFImageWriter.java
@@ -436,6 +436,8 @@ public class TIFFImageWriter extends ImageWriter {
             } catch(IIOException e) {
                 // XXX Warning
                 return null;
+            } finally {
+              bogusWriter.dispose();
             }
         }
 

--- a/src/main/java/com/github/jaiimageio/impl/plugins/tiff/TIFFImageWriter.java
+++ b/src/main/java/com/github/jaiimageio/impl/plugins/tiff/TIFFImageWriter.java
@@ -3626,6 +3626,9 @@ public class TIFFImageWriter extends ImageWriter {
         imageType = null;
         byteOrder = null;
         param = null;
+        if(compressor != null){
+          compressor.dispose();
+        }
         compressor = null;
         colorConverter = null;
         streamMetadata = null;

--- a/src/main/java/com/github/jaiimageio/plugins/tiff/TIFFCompressor.java
+++ b/src/main/java/com/github/jaiimageio/plugins/tiff/TIFFCompressor.java
@@ -278,5 +278,23 @@ public abstract class TIFFCompressor {
                                int width, int height,
                                int[] bitsPerSample,
                                int scanlineStride) throws IOException;
+                               
+   /**
+     * Allows any resources held by this object to be released.  The
+     * result of calling any other method (other than
+     * <code>finalize</code>) subsequent to a call to this method
+     * is undefined.
+     *
+     * <p>It is important for applications to call this method when they
+     * know they will no longer be using this <code>TIFFCompressor</code>.
+     * Otherwise, the writer may continue to hold on to resources
+     * indefinitely.
+     *
+     * <p>The default implementation of this method in the superclass does
+     * nothing.  Subclass implementations should ensure that all resources,
+     * especially native resources, are released.
+     */
+    public void dispose() {
+    }
 
 }


### PR DESCRIPTION
When writing a TIFF using DEFLATE as compression algorithm, a `java.util.zip.Deflate` instance is created. This instance uses native resources, which are only released when `Deflate#end()` is called, or when the `finalize` method is invoked.

In order to avoid relying on GC to clean up the native resources through the finalizer, the `TIFFDeflater` class should call `end()` when it is disposed. In order to do this, I had to add a `dispose` method to the `TIFFCompressor` class and call it from the `TIFFImageWriter`.

The `TIFFImageWriter` already has a `dispose` method, which will now call the `dispose` method of the `TIFFCompressor`. As a result, everybody who is using the `TIFFImageWriter` class correctly (calling `dispose` when finished) will benefit from this fix.

Inside the `TIFFImageWriter` class, there was a `bogusWriter` created, on which the `dispose` call was lacking. I added this call as well.