### PR TITLE
Issue 19: replacing sun classname in Metadata/parseIFD.

### DIFF
--- a/src/main/java/com/github/jaiimageio/impl/plugins/tiff/TIFFImageMetadata.java
+++ b/src/main/java/com/github/jaiimageio/impl/plugins/tiff/TIFFImageMetadata.java
@@ -74,6 +74,12 @@ public class TIFFImageMetadata extends IIOMetadata {
 
     // package scope
 
+    public static final String SUN_BaselineTIFFTagSetClassName =
+        "com.sun.media.imageio.plugins.tiff.BaselineTIFFTagSet" ;
+
+    public static final String THISJAI_BaselineTIFFTagSetClassName =
+        "com.github.jaiimageio.plugins.tiff.BaselineTIFFTagSet";
+
     public static final String nativeMetadataFormatName =
         "com_sun_media_imageio_plugins_tiff_image_1.0";
 
@@ -1500,6 +1506,10 @@ public class TIFFImageMetadata extends IIOMetadata {
             StringTokenizer st = new StringTokenizer(tagSetNames, ",");
             while (st.hasMoreTokens()) {
                 String className = st.nextToken();
+
+                if(className != null) {
+                    className = className.replace(SUN_BaselineTIFFTagSetClassName, THISJAI_BaselineTIFFTagSetClassName);
+                }
                 
                 Object o = null;
                 try {


### PR DESCRIPTION
This patch handles the error described in the issue 19, a class name hard coded referencing SUN jai_imageio in some versions of pdfbox.
If this plugin is activated, the name of the SUN class, if found, is replaced with the class existing inside the plugin itself by a filter.

Reference:
issue 19: https://github.com/jai-imageio/jai-imageio-core/issues/19
