### PR TITLE
PackageUtil: Fix NPE

### DIFF
--- a/src/main/java/com/github/jaiimageio/impl/common/PackageUtil.java
+++ b/src/main/java/com/github/jaiimageio/impl/common/PackageUtil.java
@@ -95,6 +95,10 @@ public class PackageUtil {
             }
         } catch(ClassNotFoundException e) {
         }
+
+      // For some reason, we failed to get this information.
+      if (vendor == null) vendor = "Unknown";
+      if (version == null) version = "Unknown";
     }
 
     /**


### PR DESCRIPTION
Fixes NPE that occurred when jai_imageio.jar was placed in `$JAVA_HOME/jre/lib/ext`

Derived from https://github.com/rleigh-codelibre/jai-tidy/commit/33043b8c56cb4cf1dfa91b707772e2aecad69951 and https://github.com/openmicroscopy/bioformats/commit/2a21abfdded055ca6b6a50b84b12e9df73f6373a and updated to be a little more friendly.

/cc @melissalinkert @sbesson @jburel 