### PR TITLE
jaiimageio: Fix Javadoc warnings

### DIFF
--- a/src/main/java/com/github/jaiimageio/impl/common/PaletteBuilder.java
+++ b/src/main/java/com/github/jaiimageio/impl/common/PaletteBuilder.java
@@ -106,9 +106,9 @@ public class PaletteBuilder {
      * is unable to create approximation of <code>src</code>
      * and <code>canCreatePalette</code> returns <code>false</code>.
      *
-     * @see createIndexColorModel
+     * @see #createIndexColorModel(RenderedImage)
      *
-     * @see canCreatePalette
+     * @see #canCreatePalette(RenderedImage)
      *
      */
     public static RenderedImage createIndexedImage(RenderedImage src) {
@@ -129,9 +129,9 @@ public class PaletteBuilder {
      * is unable to create approximation of <code>img</code>
      * and <code>canCreatePalette</code> returns <code>false</code>.
      *
-     * @see createIndexedImage
+     * @see #createIndexedImage(RenderedImage)
      *
-     * @see canCreatePalette
+     * @see #canCreatePalette(RenderedImage)
      *
      */
     public static IndexColorModel createIndexColorModel(RenderedImage img) {

--- a/src/main/java/com/github/jaiimageio/impl/common/SingleTileRenderedImage.java
+++ b/src/main/java/com/github/jaiimageio/impl/common/SingleTileRenderedImage.java
@@ -60,7 +60,7 @@ public class SingleTileRenderedImage extends SimpleRenderedImage {
      * and a ColorModel.
      *
      * @param ras A Raster that will define tile (0, 0) of the image.
-     * @param cm A ColorModel that will serve as the image's
+     * @param colorModel A ColorModel that will serve as the image's
      *           ColorModel.
      */
     public SingleTileRenderedImage(Raster ras, ColorModel colorModel) {

--- a/src/main/java/com/github/jaiimageio/impl/plugins/raw/RawImageReader.java
+++ b/src/main/java/com/github/jaiimageio/impl/plugins/raw/RawImageReader.java
@@ -96,7 +96,7 @@ public class RawImageReader extends ImageReader {
     }
 
     /** Overrides the method defined in the superclass.
-     *  @throw ClassCastException If the provided <code>input</code> is not
+     *  @throws ClassCastException If the provided <code>input</code> is not
      *          an instance of <code>RawImageInputImage</code>
      */
     public void setInput(Object input,

--- a/src/main/java/com/github/jaiimageio/impl/plugins/tiff/TIFFBaseJPEGCompressor.java
+++ b/src/main/java/com/github/jaiimageio/impl/plugins/tiff/TIFFBaseJPEGCompressor.java
@@ -100,13 +100,13 @@ public abstract class TIFFBaseJPEGCompressor extends TIFFCompressor {
 
     /**
      * ImageWriteParam for JPEG writer.
-     * May be initialized by {@link #initJPEGWriter()}.
+     * May be initialized by {@link #initJPEGWriter(boolean, boolean)}.
      */
     protected JPEGImageWriteParam JPEGParam = null;
 
     /**
      * The JPEG writer.
-     * May be initialized by {@link #initJPEGWriter()}.
+     * May be initialized by {@link #initJPEGWriter(boolean, boolean)}.
      */
     protected ImageWriter JPEGWriter = null;
 
@@ -121,7 +121,7 @@ public abstract class TIFFBaseJPEGCompressor extends TIFFCompressor {
      * Stream metadata equivalent to a tables-only stream such as in
      * the <code>JPEGTables</code>. Default value is <code>null</code>.
      * This should be set by any subclass which sets
-     * {@link writeAbbreviatedStream} to <code>true</code>.
+     * {@link #writeAbbreviatedStream} to <code>true</code>.
      */
     protected IIOMetadata JPEGStreamMetadata = null;
 


### PR DESCRIPTION
From https://github.com/rleigh-codelibre/jai-tidy/commit/c255dae38f05c9ca491b14e1a593d71bdc1eed8a

A collection of fairly trivial javadoc warning fixes.