### PR TITLE
* According to the Metadataworkinggroup's Guidelines for handling ima…

### DIFF
--- a/src/main/java/com/github/jaiimageio/impl/plugins/tiff/TIFFIFD.java
+++ b/src/main/java/com/github/jaiimageio/impl/plugins/tiff/TIFFIFD.java
@@ -260,7 +260,7 @@ public class TIFFIFD extends TIFFDirectory {
                                 if (inString) {
                                 // end of string
                                     String s = new String(bvalues, prevIndex,
-                                                          index - prevIndex);
+                                                          index - prevIndex, "UTF-8");
                                     v.add(s);
                                     inString = false;
                                 }


### PR DESCRIPTION
Small fix to be compliant with the [Metadata working group](http://www.metadataworkinggroup.org/) guidelines. For them, which includes Adobe, TIFF data of type ASCII should be written as UTF-8 (code is ok) and possibly read as UTF-8 (my patch) (see pages 32 and 33 of the guideline 2.0 document). Therefore i just changed the encoding format for reading, hoping i did not miss anything. Possibly can you add it to your master?



