### PR TITLE
Fix: https://github.com/jai-imageio/jai-imageio-core/issues/59

### DIFF
--- a/src/main/java/com/github/jaiimageio/impl/plugins/tiff/TIFFImageReader.java
+++ b/src/main/java/com/github/jaiimageio/impl/plugins/tiff/TIFFImageReader.java
@@ -1462,7 +1462,7 @@ public class TIFFImageReader extends ImageReader {
     }
     
     protected static BufferedImage getDestination(ImageReadParam param,
-                                                  Iterator imageTypes,
+                                                  Iterator<ImageTypeSpecifier> imageTypes,
                                                   int width, int height)
             throws IIOException {
         if (imageTypes == null || !imageTypes.hasNext()) {


### PR DESCRIPTION
bug: unable to read large resolution tiff files.
getDestination() call always goes to base class, due to having raw type Iterator parameter in the TIFFImageReader class.