### PR TITLE
Fix a bug in CLibImageReader

### DIFF
--- a/src/main/java/com/github/jaiimageio/impl/plugins/clib/CLibImageReader.java
+++ b/src/main/java/com/github/jaiimageio/impl/plugins/clib/CLibImageReader.java
@@ -160,7 +160,7 @@ public abstract class CLibImageReader extends ImageReader {
 
         SoloIterator(Object o) {
             if(o == null) {
-                new IllegalArgumentException
+                throw new IllegalArgumentException
                     (I18N.getString("CLibImageReader0"));
             }
             theObject = o;


### PR DESCRIPTION
The `IllegalArgumentException` is created but never thrown. This is almost certainly a bug.