### PR TITLE
Add FaxTIFFTagSet to supported conversion classes

### DIFF
--- a/.github/workflows/dependency_enforcement.yml
+++ b/.github/workflows/dependency_enforcement.yml
@@ -1,0 +1,20 @@
+# For most projects, this workflow file will not need changing; you simply need
+# to commit it to your repository.
+#
+# Reach out on Teams at 'Corp DevOps / Github Community' to get help.
+
+name: "Dependency Review"
+on: [pull_request]
+permissions:
+  contents: read
+jobs:
+  dependency-review:
+    runs-on: ubuntu-latest
+    steps:
+      - name: "Checkout Repository"
+        uses: actions/checkout@v4
+      - name: Dependency Review
+        uses: actions/dependency-review-action@v4
+        with:
+          fail-on-severity: high
+          fail-on-scopes: runtime, development

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
   </prerequisites>
   <groupId>com.github.jai-imageio</groupId>
   <artifactId>jai-imageio-core</artifactId>
-  <version>1.4.1-SNAPSHOT</version>
+  <version>1.4.1-tylertech-SNAPSHOT</version>
   <packaging>bundle</packaging>
   <name>Java Advanced Imaging Image I/O Tools API core (standalone)</name>
   <description>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
   </prerequisites>
   <groupId>com.github.jai-imageio</groupId>
   <artifactId>jai-imageio-core</artifactId>
-  <version>1.4.1-tylertech-SNAPSHOT</version>
+  <version>1.4.1-SNAPSHOT</version>
   <packaging>bundle</packaging>
   <name>Java Advanced Imaging Image I/O Tools API core (standalone)</name>
   <description>

--- a/src/main/java/com/github/jaiimageio/impl/plugins/tiff/TIFFImageMetadata.java
+++ b/src/main/java/com/github/jaiimageio/impl/plugins/tiff/TIFFImageMetadata.java
@@ -73,7 +73,13 @@ import com.github.jaiimageio.plugins.tiff.TIFFTagSet;
 public class TIFFImageMetadata extends IIOMetadata {
 
     // package scope
-
+    
+    public static final String SUN_FaxTIFFTagSetClassName =
+                    "com.sun.media.imageio.plugins.tiff.FaxTIFFTagSet" ;
+    
+    public static final String THISJAI_FaxTIFFTagSetClassName =
+                    "com.github.jaiimageio.plugins.tiff.FaxTIFFTagSet";
+    
     public static final String SUN_BaselineTIFFTagSetClassName =
         "com.sun.media.imageio.plugins.tiff.BaselineTIFFTagSet" ;
 
@@ -1512,6 +1518,7 @@ public class TIFFImageMetadata extends IIOMetadata {
 
                 if(className != null) {
                     className = className.replace(SUN_BaselineTIFFTagSetClassName, THISJAI_BaselineTIFFTagSetClassName);
+                    className = className.replace(SUN_FaxTIFFTagSetClassName, THISJAI_FaxTIFFTagSetClassName);
                 }
                 
                 Object o = null;

--- a/src/main/java/com/github/jaiimageio/impl/plugins/tiff/TIFFImageMetadata.java
+++ b/src/main/java/com/github/jaiimageio/impl/plugins/tiff/TIFFImageMetadata.java
@@ -73,7 +73,13 @@ import com.github.jaiimageio.plugins.tiff.TIFFTagSet;
 public class TIFFImageMetadata extends IIOMetadata {
 
     // package scope
-    
+
+    public static final String SUN_EXIFParentTIFFTagSetClassName =
+            "com.sun.media.imageio.plugins.tiff.EXIFParentTIFFTagSet" ;
+
+    public static final String THISJAI_EXIFParentTIFFTagSetClassName =
+            "com.github.jaiimageio.plugins.tiff.EXIFParentTIFFTagSet";
+
     public static final String SUN_FaxTIFFTagSetClassName =
                     "com.sun.media.imageio.plugins.tiff.FaxTIFFTagSet" ;
     
@@ -1519,6 +1525,7 @@ public class TIFFImageMetadata extends IIOMetadata {
                 if(className != null) {
                     className = className.replace(SUN_BaselineTIFFTagSetClassName, THISJAI_BaselineTIFFTagSetClassName);
                     className = className.replace(SUN_FaxTIFFTagSetClassName, THISJAI_FaxTIFFTagSetClassName);
+                    className = className.replace(SUN_EXIFParentTIFFTagSetClassName, THISJAI_EXIFParentTIFFTagSetClassName);
                 }
                 
                 Object o = null;

--- a/src/test/java/com/github/jaiimageio/impl/plugins/tiff/TIFFImageMetadataTest.java
+++ b/src/test/java/com/github/jaiimageio/impl/plugins/tiff/TIFFImageMetadataTest.java
@@ -2,6 +2,7 @@ package com.github.jaiimageio.impl.plugins.tiff;
 
 
 import com.github.jaiimageio.plugins.tiff.BaselineTIFFTagSet;
+import com.github.jaiimageio.plugins.tiff.EXIFParentTIFFTagSet;
 import com.github.jaiimageio.plugins.tiff.FaxTIFFTagSet;
 import com.sun.org.apache.xerces.internal.dom.DocumentImpl;
 import org.junit.Test;
@@ -14,7 +15,19 @@ import javax.imageio.metadata.IIOInvalidTreeException;
 import static junit.framework.TestCase.assertEquals;
 
 public class TIFFImageMetadataTest {
-    
+
+    @Test
+    public void test_parseIFD_SUN_EXIFParentTIFFTagSetClassName() throws IIOInvalidTreeException {
+        Document xmlDoc = new DocumentImpl();
+        Element ifd = xmlDoc.createElement("TIFFIFD");
+        ifd.setAttribute("tagSets", TIFFImageMetadata.SUN_EXIFParentTIFFTagSetClassName);
+
+        TIFFIFD tiffIfd = TIFFImageMetadata.parseIFD(ifd);
+
+        assertEquals(1, tiffIfd.getTagSetList().size());
+        assertEquals(EXIFParentTIFFTagSet.class.getName(), tiffIfd.getTagSetList().get(0).getClass().getName());
+    }
+
     @Test
     public void test_parseIFD_SUN_FaxTIFFTagSetClassName() throws IIOInvalidTreeException {
         Document xmlDoc = new DocumentImpl();

--- a/src/test/java/com/github/jaiimageio/impl/plugins/tiff/TIFFImageMetadataTest.java
+++ b/src/test/java/com/github/jaiimageio/impl/plugins/tiff/TIFFImageMetadataTest.java
@@ -1,0 +1,42 @@
+package com.github.jaiimageio.impl.plugins.tiff;
+
+
+import com.github.jaiimageio.plugins.tiff.BaselineTIFFTagSet;
+import com.github.jaiimageio.plugins.tiff.FaxTIFFTagSet;
+import com.sun.org.apache.xerces.internal.dom.DocumentImpl;
+import org.junit.Test;
+
+import com.github.jaiimageio.impl.plugins.tiff.TIFFImageMetadata;
+import org.w3c.dom.*;
+
+import javax.imageio.metadata.IIOInvalidTreeException;
+
+import static junit.framework.TestCase.assertEquals;
+
+public class TIFFImageMetadataTest {
+    
+    @Test
+    public void test_parseIFD_SUN_FaxTIFFTagSetClassName() throws IIOInvalidTreeException {
+        Document xmlDoc = new DocumentImpl();
+        Element ifd = xmlDoc.createElement("TIFFIFD");
+        ifd.setAttribute("tagSets", TIFFImageMetadata.SUN_FaxTIFFTagSetClassName);
+        
+	TIFFIFD tiffIfd = TIFFImageMetadata.parseIFD(ifd);
+	
+	assertEquals(1, tiffIfd.getTagSetList().size());
+	assertEquals(FaxTIFFTagSet.class.getName(), tiffIfd.getTagSetList().get(0).getClass().getName());
+    }
+    
+    @Test
+    public void test_parseIFD_SUN_BaselineTIFFTagSetClassName() throws IIOInvalidTreeException {
+	Document xmlDoc = new DocumentImpl();
+	Element ifd = xmlDoc.createElement("TIFFIFD");
+	ifd.setAttribute("tagSets", TIFFImageMetadata.SUN_BaselineTIFFTagSetClassName);
+	
+	TIFFIFD tiffIfd = TIFFImageMetadata.parseIFD(ifd);
+	
+	assertEquals(1, tiffIfd.getTagSetList().size());
+	assertEquals(BaselineTIFFTagSet.class.getName(), tiffIfd.getTagSetList().get(0).getClass().getName());
+    }
+    
+}


### PR DESCRIPTION
Opening a PR for adding FaxTIFFTagSet to the supported classes for conversion on this project; we had an issue on our end where we were running into ClassNotFoundExceptions without this change, and decided to add it as the other class was prior.