### PR TITLE
Fix for: OSGi - jai-imageio-jpeg2000 requires unprovided package #81

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -138,7 +138,7 @@
           <instructions>
             <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
             <Import-Package>*</Import-Package>
-            <Export-Package>{local-packages}</Export-Package>
+            <Export-Package>{local-packages}, com.github.jaiimageio.impl.common</Export-Package>
           </instructions>
           <supportedProjectTypes>
             <supportedProjectType>jar</supportedProjectType>


### PR DESCRIPTION
Added missing OSGi package export used by jai-imageio-jpeg2000